### PR TITLE
chore(codeowners): set github code owners to define default pull request reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @readysteadywhoa @IanEdington @azend


### PR DESCRIPTION
This PR sets `CODEOWNERS` to define a default set of reviewers when submitting new PRs. This is advantageous as it allows new developers to have their PRs reviewed without knowledge of who to contact for review. It also gives reviewers freedom to add or remove themselves from the list as their roles, responsibilities, and availability change.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/
