### PR TITLE
Remove membership from the admins "New Member Email"

### DIFF
--- a/config/kwartzlabos.php
+++ b/config/kwartzlabos.php
@@ -19,8 +19,8 @@ return [
 
     'membership_app' => [                       // membership app email configuration for admin and members mailings
         'admin' => [
-            'to' => 'membership@kwartzlab.ca',
-            'cc' => 'bod@kwartzlab.ca',
+            'to' => 'bod@kwartzlab.ca',
+            'cc' => null,
             'replyto' => null,
             'subject' => 'New Member App [BoD Version]',
         ],


### PR DESCRIPTION
Currently the admin version of the New Member Email goes to both the
membership@kwartzlab.ca email and the bod@kwartzlab.ca email. As we move
towards sharing access to the membership email with a select few
members, sensitive data included in the admin version of the email
shouldn't be included.
