### PR TITLE
feat: hide trainer names in the tool directory if they are not active members

### DIFF
--- a/resources/views/gatekeeper/profile.blade.php
+++ b/resources/views/gatekeeper/profile.blade.php
@@ -39,7 +39,9 @@
                         @if (count($trainers)>0)
                            <h5 style="margin-bottom:0px;">Trainers</h5>   
                            @foreach($trainers as $trainer)
-                              <a href="/members/{{ $trainer->user()->first()->id }}/profile" title="View Profile"><span class="badge badge-primary badge-large">{{ $trainer->user()->first()->get_name() }}</span></a>&nbsp;
+                              @if ($trainer->user()->first()->status == 'active') 
+                                 <a href="/members/{{ $trainer->user()->first()->id }}/profile" title="View Profile"><span class="badge badge-primary badge-large">{{ $trainer->user()->first()->get_name() }}</span></a>&nbsp;
+                              @endif
                            @endforeach
                         @endif
                         @php ($maintainers = $gatekeeper->maintainers()->get())

--- a/resources/views/gatekeeper/profile.blade.php
+++ b/resources/views/gatekeeper/profile.blade.php
@@ -35,13 +35,11 @@
                   </div>
                   <div class="row">
                      <div class="col">
-                        @php ($trainers = $gatekeeper->trainers()->get())
+                        @php ($trainers = $gatekeeper->trainers()->whereHas('user', function($query) { $query->where('status', 'active'); })->get())
                         @if (count($trainers)>0)
                            <h5 style="margin-bottom:0px;">Trainers</h5>   
                            @foreach($trainers as $trainer)
-                              @if ($trainer->user()->first()->status == 'active') 
                                  <a href="/members/{{ $trainer->user()->first()->id }}/profile" title="View Profile"><span class="badge badge-primary badge-large">{{ $trainer->user()->first()->get_name() }}</span></a>&nbsp;
-                              @endif
                            @endforeach
                         @endif
                         @php ($maintainers = $gatekeeper->maintainers()->get())

--- a/resources/views/gatekeeper/profile.blade.php
+++ b/resources/views/gatekeeper/profile.blade.php
@@ -35,7 +35,7 @@
                   </div>
                   <div class="row">
                      <div class="col">
-                        @php ($trainers = $gatekeeper->trainers()->whereHas('user', function($query) { $query->where('status', 'active'); })->get())
+                        @php ($trainers = $gatekeeper->trainers()->whereRelation('user', 'status', 'active')->get())
                         @if (count($trainers)>0)
                            <h5 style="margin-bottom:0px;">Trainers</h5>   
                            @foreach($trainers as $trainer)

--- a/resources/views/gatekeeper/profile.blade.php
+++ b/resources/views/gatekeeper/profile.blade.php
@@ -39,7 +39,7 @@
                         @if (count($trainers)>0)
                            <h5 style="margin-bottom:0px;">Trainers</h5>   
                            @foreach($trainers as $trainer)
-                                 <a href="/members/{{ $trainer->user()->first()->id }}/profile" title="View Profile"><span class="badge badge-primary badge-large">{{ $trainer->user()->first()->get_name() }}</span></a>&nbsp;
+                              <a href="/members/{{ $trainer->user()->first()->id }}/profile" title="View Profile"><span class="badge badge-primary badge-large">{{ $trainer->user()->first()->get_name() }}</span></a>&nbsp;
                            @endforeach
                         @endif
                         @php ($maintainers = $gatekeeper->maintainers()->get())


### PR DESCRIPTION
Fixes issue #3 by removing inactive trainers from the list of available tool trainers. This can also be implemented by showing the trainer name but with a different label colour. I chose not to do it that way because a) it adds additional complexity and b) it provides a level of visibility into member statuses that could and maybe should very well be private.
