### PR TITLE
chore(config): updated membership coordinator name

### DIFF
--- a/config/kwartzlabos.php
+++ b/config/kwartzlabos.php
@@ -18,7 +18,7 @@ return [
     'entrance_gatekeepers' => [11],             // which gatekeepers are building entrances (used for metrics)
 
     'membership_coordinator' => [
-        'name' => 'Ian Edington',
+        'name' => 'Laura Schuhbauer',
     ],
     'membership_app' => [                       // membership app email configuration for admin and members mailings
         'admin' => [

--- a/tests/Feature/Http/Controllers/FormsControllerTest.php
+++ b/tests/Feature/Http/Controllers/FormsControllerTest.php
@@ -76,7 +76,7 @@ class FormsControllerTest extends TestCase
             $mail->assertHasSubject('Application Received - Kwartzlab Makerspace');
             $mail->assertSeeInOrderInHtml([
                 $newUser->get_name(),
-                'Ian Edington',
+                config('kwartzlabos.membership_coordinator.name'),
                 'Membership Coordinator',
                 'membership@kwartzlab.ca',
             ]);


### PR DESCRIPTION
This PR updates the `membership_coordinator` configuration value from Ian to Laura as per the most recent election. Please note that changes will not take effect until this change is merged and deployed to the server hosting kOS.
