### PR TITLE
feat(config): add inactive in memoriam status for members who have since passed away

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -184,6 +184,10 @@ class UsersController extends Controller
                     $status->status = 'inactive-abandoned';
                     $status->save();
                     break;
+                case 'inactive-in-memoriam':
+                    $status->status = 'inactive-in-memoriam';
+                    $status->save();
+                    break;
                 case 'hiatus':
                     // create both the hiatus record and the active record for when hiatus is over
                     $status->status = 'hiatus';

--- a/app/Models/UserStatus.php
+++ b/app/Models/UserStatus.php
@@ -29,6 +29,8 @@ class UserStatus extends Model implements Auditable
 
     public const STATUS_APPLICANT = 'applicant';
 
+    public const STATUS_INACTIVE_IN_MEMORIAM = 'inactive-in-memoriam';
+
     public const STATUSES_TO_ACTIVE_SEND_INVITES = [
         self::STATUS_INACTIVE,
         self::STATUS_TERMINATED,

--- a/app/Traits/UserStatusTrait.php
+++ b/app/Traits/UserStatusTrait.php
@@ -43,7 +43,7 @@ trait UserStatusTrait
                     $extra_tasks = '(New Member Induction)';
                     $user->date_admitted = $current_status->created_at;
                 }
-                if (($current_status->status == 'inactive') || ($current_status->status == 'inactive-abandoned') || ($current_status->status == 'terminated')) {
+                if (($current_status->status == 'inactive') || ($current_status->status == 'inactive-abandoned') || ($current_status->status == 'terminated') || ($current_status->status == 'terminated')) {
                     $user->date_withdrawn = $current_status->created_at;
                 }
 

--- a/config/kwartzlabos.php
+++ b/config/kwartzlabos.php
@@ -75,6 +75,12 @@ return [
             'colour' => 'danger',
             'send-notifications' => true,
         ],
+        'inactive-in-memoriam' => [
+            'name' => 'In Memoriam',
+            'icon' => 'fa-user-slash',
+            'colour' => 'danger',
+            'send-notifications' => false,
+        ],
         'terminated' => [
             'name' => 'Withdrawn [Terminated]',
             'icon' => 'fa-user-slash',

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -56,6 +56,7 @@ class UsersTableSeeder extends Seeder
         $this->createUsers(UserStatus::STATUS_APPLICANT_ABANDONED, 10);
         $this->createUsers(UserStatus::STATUS_APPLICANT_DENIED, 5);
         $this->createUsers(UserStatus::STATUS_APPLICANT, 5);
+        $this->createUsers(UserStatus::STATUS_INACTIVE_IN_MEMORIAM, 5);
     }
 
     private function createUsers(string $status, int $count = 1): void

--- a/resources/views/users/profile.blade.php
+++ b/resources/views/users/profile.blade.php
@@ -26,6 +26,9 @@
                @case('abandoned')
                   <h5>Withdrawn {{ $user->last_status('abandoned')->first()->created_at->format('Y-m-d') }}</h5>
                @break
+               @case('inactive-in-memoriam')
+                  <h5>In Memoriam {{ $user->last_status('inactive-in-memoriam')->first()->created_at->format('Y-m-d') }}
+               @break
                @case('hiatus')
                   <h5>On Hiatus until {{ $user->last_status('active')->first()->created_at->format('Y-m-d') }}</h5>
                @break


### PR DESCRIPTION
This PR creates a special membership status designated to people part of our membership that have passed away.
