### PR TITLE
Search for members by email address

### DIFF
--- a/resources/views/members/index.blade.php
+++ b/resources/views/members/index.blade.php
@@ -16,6 +16,7 @@
          <table class="table table-striped" id="data-table">
             <thead><tr>
                <th>Name</th>
+               <th>Email</th>
                <th>Joined</th>
                <th>Status</th>
                <th>Team(s)</th>
@@ -25,6 +26,7 @@
                @foreach($users as $user)
                   <tr>
                      <td>{{ $user->get_name() }}</td>
+                     <td>{{ $user->email }}</td>
                      <td nowrap>@isset($user->date_admitted) {{ $user->date_admitted->toDateString() }} @endisset</td>
                      <td>@include('users.status')
                      @php ($roles = $user->roles()->get())
@@ -73,8 +75,18 @@
 				iDisplayLength: {{ config('kwartzlabos.results_per_page.default') }},
 				"language": {
 					"emptyTable": "No results???"
-				}
+				},
+                                // Enable member search by email without displaying the email address.
+                                columnDefs: [{
+                                        targets: 1, // Email column
+                                        visible: false
+                                }]
 			});
+
+            // Hiding a column with data tables gives the table a goofy behaviour where the table itself shrinks in width.
+            // This is a known issue where the "fix" is to reset the table back to full width once the column has been
+            // hidden.
+            $('#data-table').width('100%');
         });
     </script>
 @stop

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -25,6 +25,7 @@
             <thead><tr>
                <th scope="col">First Name</th>
                <th scope="col">Last Name</th>
+               <th scope="col">Email</th>
                <th scope="col">Status / Role</th>
                <th scope="col">Team(s)</th>
                <th scope="col"># Keys</th>
@@ -35,6 +36,7 @@
                   <tr>
                      <td>{{ $user->get_name('first') }}</td>
                      <td>{{ $user->get_name('last') }}</td>
+                     <td>{{ $user->email }}</td>
                      <td>@include('users.status')
                      @foreach($user->roles()->get() as $role)
                         @if($role->id>1)
@@ -73,15 +75,14 @@
 @section('js')
    <script>
         $(document).ready(function () {
-            $('#data-table').dataTable({
+          $('#data-table').dataTable({
             ordering: false,
             pagingType: "simple_numbers",
             iDisplayLength: {{ config('kwartzlabos.results_per_page.default') }},
             "language": {
-               "emptyTable": "No results."
+              "emptyTable": "No results."
             }
-         });
-
+          });
         });
 
         function modal_do_stuff_success(data) {


### PR DESCRIPTION
This PR makes both members lists (the directory accessible by all members and the registry accessible by admin users) searchable by email address. The administrative register provides an additional email column which is visible to view, filter, and sort. The directory allows filtering by email but the column data is hidden without continuing through to view the profile.
