### PR TITLE
bug: force git to use unix style line endings to not break docker

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
-* text=auto
+* text=auto eol=lf
+
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf
+
 *.css linguist-vendored
 *.scss linguist-vendored


### PR DESCRIPTION
Force Git on Windows to use posix style line endings to fix issues with Docker execution.
