### PR TITLE
ci: update github runner image version because latest is two years old

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -25,7 +25,7 @@ jobs:
         run: phpunit
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
@@ -45,7 +45,7 @@ jobs:
         run: pint --test
 
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Update the Github runner image version from `latest` = `ubuntu-22.04` to `ubuntu-24.04`. Both versions are LTS but the latter includes PHP 8.3 which is compatible with our composer requirements.