### PR TITLE
bug: fix typo pluralizing team roles in input labels when creating new teams

### DIFF
--- a/resources/views/teams/create.blade.php
+++ b/resources/views/teams/create.blade.php
@@ -34,7 +34,7 @@
           @if((!$team_data['is_trainer']) && (!$team_data['is_maintainer']))
             <div class="row">
               <div class="form-group col-md-6">
-                <label for="{{ $team_role }}[]">{{ $team_data['name'] }}s</label>
+                <label for="{{ $team_role }}[]">{{ $team_data['plural_name'] }}</label>
                 <select multiple class="form-control" name="{{ $team_role }}[]" id="{{ $team_role }}">
                   @foreach($user_list as $key => $value)
                       <option value="{{ $key }}" @if(old($team_role, null) != null) @if (in_array($key, old($team_role))) selected="selected" @endif @endif>{{ $value }}</option>


### PR DESCRIPTION
This PR fixes issue #70 where team role names are pluralized by using the singular name and appending an 's' as a suffix. Now the view pulls in an additional attribute already available from the config that defines team role names already in plural form.

Before:
<img width="978" alt="Screenshot 2024-11-01 at 5 39 42 PM" src="https://github.com/user-attachments/assets/50343168-c02b-482d-96ea-f509205e1412">

After:
<img width="994" alt="Screenshot 2024-11-01 at 5 40 21 PM" src="https://github.com/user-attachments/assets/62f3f83a-0d0f-4efe-855b-08fc40831b45">
