### PR TITLE
feat(tools): display offline only tools with no status as offline instead of unknown

### DIFF
--- a/resources/views/gatekeeper/profile.blade.php
+++ b/resources/views/gatekeeper/profile.blade.php
@@ -29,7 +29,7 @@
                <div class="col-md-8">
                   <div class="row">
                      <div class="col-md-8">
-                        @php($status = $gatekeeper->current_status()->get()->first())
+                        @php($status = $gatekeeper->current_status()->first())
                         @include('gatekeeper.status')
                      </div>
                   </div>

--- a/resources/views/gatekeeper/status.blade.php
+++ b/resources/views/gatekeeper/status.blade.php
@@ -41,11 +41,11 @@
       </div>
    @endif
 @else
-   <div class="info-box bg-warning">
-      <span class="info-box-icon"><i class="fas fa-exclamation-triangle"></i></span>
+   <div class="info-box bg-secondary">
+      <span class="info-box-icon"><i class="fas fa-eye-slash"></i></span>
       <div class="info-box-content">
          <span class="info-box-text">Status</span>
-         <span class="info-box-number">Unknown</span>
+         <span class="info-box-number">Offline - Does not report status</span>
       </div>
    </div>
 @endif


### PR DESCRIPTION
So I don’t know if I’m the only one but, while browsing through the list of tools in kOS, there’s a yellow warning box that shows up for every tool that has never generated a status and I don’t like it. It’s bright and tries to warn you. But there’s nothing to warn about. It’s just a tool that isn’t connected to kOS. Screenshot for demonstration:
<img width="1679" alt="Screenshot 2024-11-01 at 6 51 52 PM" src="https://github.com/user-attachments/assets/3a7c7c4a-4056-4bec-8958-5fe2ce5e0af9">

I’d like to either hide this warning entirely or show a message instead that the tool is an offline only tool and in a manner that’s a bit more calm. Here’s screenshots to show what it might look like:
<img width="1679" alt="Screenshot 2024-11-01 at 6 59 46 PM" src="https://github.com/user-attachments/assets/e95b6c08-afd3-4c77-87a8-b91cd2711538">
<img width="1679" alt="Screenshot 2024-11-01 at 6 49 33 PM" src="https://github.com/user-attachments/assets/07d83f56-4379-4015-8757-452ffec31989">

This PR implements the grey option where a status is still visible but less alarming than warning yellow.

Alternatively we create a switch for offline only tools to allow creation and modification of status manually from within kOS. This could enable users to report breakage or maintenance and provide reason visible to other members within the tools interface.