### PR TITLE
chore(sec): fix database connection after enabling ssl

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -46,6 +46,7 @@ return [
             'database' => env('DB_DATABASE', 'forge'),
             'username' => env('DB_USERNAME', 'forge'),
             'password' => env('DB_PASSWORD', ''),
+            'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',


### PR DESCRIPTION
I enforced SSL on the mysql server since the BOD asked for access. However, this caused our application connection to lose connection. Adding a UNIX socket connection mirrors the way the `mysql-client` accesses the database.

This change is currently on the server as a hotfix. DO NOT DEPLOY until this is merged!