### PR TITLE
fix: Fixes abandoned date not being displayed on abandoned users

### DIFF
--- a/resources/views/users/profile.blade.php
+++ b/resources/views/users/profile.blade.php
@@ -23,8 +23,8 @@
                @case('inactive')
                   <h5>Withdrawn {{ $user->last_status('inactive')->first()->created_at->format('Y-m-d') }}</h5>
                @break
-               @case('abandoned')
-                  <h5>Withdrawn {{ $user->last_status('abandoned')->first()->created_at->format('Y-m-d') }}</h5>
+               @case('inactive-abandoned')
+                  <h5>Withdrawn {{ $user->last_status('inactive-abandoned')->first()->created_at->format('Y-m-d') }}</h5>
                @break
                @case('inactive-in-memoriam')
                   <h5>In Memoriam {{ $user->last_status('inactive-in-memoriam')->first()->created_at->format('Y-m-d') }}


### PR DESCRIPTION
Fixed a typo in the profile.blade.php file in users which prevented the date from being displayed.
Addresses issue #97.

![image](https://github.com/user-attachments/assets/c99499f8-0858-4e78-839a-1bf60fea19ce)

