### PR TITLE
ci: fix built docker image name

### DIFF
--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -18,7 +18,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ vars.DOCKER_USERNAME }}/my-image
+          images: ${{ vars.DOCKER_USERNAME }}/${{ vars.IMAGE_NAME }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Doh! I copy-pasta'd this CI workflow to build and publish Docker images of kOS to Docker Hub. But I missed updating the image name. I've patched the name from `my-image` to `kos-base` here.
