### PR TITLE
chore: update CODEOWNERS to reflect current contributors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @readysteadywhoa @IanEdington @azend @everett-ripley
+*       @readysteadywhoa @azend @everett-ripley


### PR DESCRIPTION
Keep Ben and Everett as `CODEOWNERS`. But remove Ian until his time and interest permits again.

<img width="476" alt="Screenshot 2025-05-24 at 10 33 46 PM" src="https://github.com/user-attachments/assets/f65152d0-9f95-41e5-b08c-ca8973a69263" />
