### PR TITLE
feat: further restrict permissions to view and access reports

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -57,6 +57,14 @@ class AuthServiceProvider extends ServiceProvider
             return Auth::user()->is_allowed('reports', 'manage');
         });
 
+        Gate::define('view-user-reports', function ($user) {
+            return Auth::user()->is_allowed('reports', 'users');
+        });
+
+        Gate::define('view-gatekeeper-reports', function ($user) {
+            return Auth::user()->is_allowed('reports', 'gatekeepers');
+        });
+
         Gate::define('manage-users-keys', function ($user) {
             if (Auth::user()->is_allowed('users', 'manage')) {
                 return true;

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,8 +91,8 @@ Route::middleware('auth')->group(function () {
 // Reports
 Route::middleware(['auth', 'can:manage-reports'])->group(function () {
     Route::get('/reports', [ReportsController::class, 'index'])->name('reports');
-    Route::get('/reports/member-status-report', [ReportsController::class, 'member_status_report'])->name('reports.member-status-report');
-    Route::get('/reports/member-activity-report', [ReportsController::class, 'member_activity_report'])->name('reports.member-activity-report');
+    Route::get('/reports/member-status-report', [ReportsController::class, 'member_status_report'])->middleware(['auth', 'can:view-user-reports'])->name('reports.member-status-report');
+    Route::get('/reports/member-activity-report', [ReportsController::class, 'member_activity_report'])->middleware(['auth', 'can:view-gatekeeper-reports'])->name('reports.member-activity-report');
 });
 
 // Gatekeeper sync and key authentication routes


### PR DESCRIPTION
This PR adds the ability to restrict reports to those with specific access permissions. To access/list any reports, a user must have at minimum the `[reports] manage` permission. But to view a report, the user must have the report specific permission. For example, the member status report requires access to the `[reports] users` permission. The member activity report requires access to the `[reports] gatekeeper` permission.

Please note that these permissions will not be set by default. This will require a user with a BoD role or above to set permissions appropriate to the defined roles. Please expect to set the bookkeeper role with at least `[reports] manage` and [reports] users`.

Superuser role:
<img width="1140" alt="Screenshot 2025-05-25 at 12 35 56 AM" src="https://github.com/user-attachments/assets/7e577c7e-66f5-4ea5-8e65-975f3e6a825b" />

Bookkeeper role:
<img width="1010" alt="Screenshot 2025-05-25 at 12 35 09 AM" src="https://github.com/user-attachments/assets/026ddc89-ff6e-4162-b9cb-b76c6494234e" />

Unpermissioned role:
<img width="270" alt="Screenshot 2025-05-25 at 12 37 00 AM" src="https://github.com/user-attachments/assets/8ee7a804-2048-4d96-9650-7e02643ba418" />
<img width="1679" alt="Screenshot 2025-05-25 at 12 37 10 AM" src="https://github.com/user-attachments/assets/9629a7e1-f48e-4a08-9f9c-68954185ce3e" />
