### PR TITLE
Added 'autocomplete' to kiosk password input to stop autofill

### DIFF
--- a/resources/views/kiosk/rfid.blade.php
+++ b/resources/views/kiosk/rfid.blade.php
@@ -27,7 +27,7 @@
 <form id="form-rfid" method="POST" action="{{ $page['form_url'] }}" style="height:1px">
   {{ csrf_field() }}
   <div class="form-group no-opacity">
-    <input type="password" class="form-control" name="rfid" id="rfid" autofocus>
+    <input type="password" class="form-control" name="rfid" id="rfid" autocomplete="new-password" autofocus>
   </div>
   <div class="form-group">
     <button type="submit" class="btn btn-primary" style="display:none">Submit</button>


### PR DESCRIPTION
Currently when on the kiosk page, it attempts to autofill the password saved for kos.kwartzlab.ca. This is causing issues with the fob reader, since the user will have to manually delete the filled password without the box being visible.

Since there's no reason for us to have autofill on this page, setting `autocomplete="new-password"` should stop the from happening