### PR TITLE
Adding routes to access membership status changes

### DIFF
--- a/app/Http/Controllers/Api/UserStatusesController.php
+++ b/app/Http/Controllers/Api/UserStatusesController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\UserStatus;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+
+class UserStatusesController extends Controller
+{
+    public function latest()
+    {
+        $status = UserStatus::query()->orderByDesc('id')->first(['id', 'created_at']);
+
+        if ($status === null) {
+            return response()->json(['id' => 0]);
+        }
+
+        return response()->json([
+            'id' => $status->id,
+            'created_at' => $status->created_at,
+        ]);
+    }
+
+    public function index(Request $request)
+    {
+        $status_id = (int) $request->query('status_id', 0);
+
+        $status = UserStatus::query()
+            ->select([
+                'id',
+                'user_id',
+                'status',
+                'note',
+                'updated_by',
+                'created_at',
+            ])
+            ->where('id', '>=', $status_id)
+            ->orderBy('id')
+            ->first();
+
+        if ($status === null) {
+            return response()->json(['message' => 'No pending user statuses.'], 204);
+        }
+
+        return response()->json($status);
+    }
+
+    public function upcoming(Request $request)
+    {
+        $days = max(1, min((int) $request->query('days', 7), 90));
+        $now = Carbon::now();
+
+        $statuses = UserStatus::query()
+            ->select(['id', 'user_id', 'status', 'note', 'updated_by', 'created_at'])
+            ->where('created_at', '>', $now)
+            ->where('created_at', '<=', $now->copy()->addDays($days))
+            ->orderBy('created_at')
+            ->get();
+
+        return response()->json($statuses);
+    }
+}

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -192,7 +192,7 @@ class UsersController extends Controller
                     $status->save();
                     $endingNote = 'Ending Hiatus';
                     if ($request->filled('note')) {
-                        $endingNote .= ' - ' . $request->input('note');
+                        $endingNote .= ' - '.$request->input('note');
                     }
                     $status_end = new \App\Models\UserStatus([
                         'user_id' => $user->id,

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -156,7 +156,7 @@ class UsersController extends Controller
                 'created_at' => $request->input('effective_date'),
                 'updated_at' => date('Y-m-d'),
             ]);
-            if ($request->has('note')) {
+            if ($request->filled('note') && $request->input('status_type') !== 'hiatus') {
                 $status->note = $request->input('note');
             }
 
@@ -190,11 +190,15 @@ class UsersController extends Controller
                     // create both the hiatus record and the active record for when hiatus is over
                     $status->status = 'hiatus';
                     $status->save();
+                    $endingNote = 'Ending Hiatus';
+                    if ($request->filled('note')) {
+                        $endingNote .= ' - ' . $request->input('note');
+                    }
                     $status_end = new \App\Models\UserStatus([
                         'user_id' => $user->id,
                         'updated_by' => \Auth::user()->id,
                         'status' => 'active',
-                        'note' => 'Ending Hiatus',
+                        'note' => $endingNote,
                         'created_at' => $request->input('effective_date_ending'),
                         'updated_at' => date('Y-m-d'),
                     ]);

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -367,6 +367,10 @@
                 </div>
                </div>
             </div>
+            <div style="margin-top:15px;">
+              <label for="status_note">Note <small class="text-muted">(optional)</small></label>
+              <input type="text" class="form-control" name="note" id="status-note" placeholder="Optional note">
+            </div>
       </div>
       </form>
       <div class="modal-footer">

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\ApiTokenController;
 use App\Http\Controllers\Api\FormSubmissionOutboxController;
 use App\Http\Controllers\Api\FormSubmissionsController;
 use App\Http\Controllers\Api\UsersController;
+use App\Http\Controllers\Api\UserStatusesController;
 use App\Http\Controllers\PublicInfoController;
 use Illuminate\Http\Request;
 
@@ -32,6 +33,10 @@ Route::middleware('api_token')->get('/form_submissions/outbox', [FormSubmissionO
 Route::middleware('api_token')->get('/form_submissions/outbox/next', [FormSubmissionOutboxController::class, 'next']);
 Route::middleware('api_token')->post('/form_submissions/outbox/{form_submission_outbox}', [FormSubmissionOutboxController::class, 'markProcessed']);
 Route::middleware('api_token')->get('/form_submissions/outbox/{form_submission_outbox}', [FormSubmissionOutboxController::class, 'show']);
+
+Route::middleware('api_token')->get('/user_statuses/latest', [UserStatusesController::class, 'latest']);
+Route::middleware('api_token')->get('/user_statuses/upcoming', [UserStatusesController::class, 'upcoming']);
+Route::middleware('api_token')->get('/user_statuses', [UserStatusesController::class, 'index']);
 
 Route::get('/public-info', [PublicInfoController::class, 'index']);
 Route::middleware('api_token')->get('/hello', function () {


### PR DESCRIPTION
Also added the ability to add a note to status changes since the field is currently only used for "Ending Hiatus".

This is needed to add status change event handling and leaving/returning member notifications with the membership automation app